### PR TITLE
fix: message over limits

### DIFF
--- a/src/js/events/ready.js
+++ b/src/js/events/ready.js
@@ -42,8 +42,7 @@ module.exports = {
 			embeds: [loginEmbed],
 		});
 
-		botHook.send({
-			content: `${serverNames}\n------------------------\n${serverIds}`
-		});
+		console.log(serverNames);
+		console.log(serverIds);
 	}
 }


### PR DESCRIPTION
如題，將webhook發送訊息上限的部份刪除，並直接console.log出來